### PR TITLE
fix System runCommand

### DIFF
--- a/libs/iovm/io/System.io
+++ b/libs/iovm/io/System.io
@@ -89,8 +89,10 @@ System do(
 		result exitStatus := exitStatus
 		result failed := method(exitStatus != successStatus)
 		result succeeded := method(exitStatus == successStatus)
-		result stdout := File with(stdoutPath) contents
-		result stderr := File with(stderrPath) contents
+        stdoutFile := File with(stdoutPath)
+        stderrFile := File with(stderrPath)
+		result stdout := if(stdoutFile exists, stdoutFile contents, nil)
+		result stderr := if(stderrFile exists, stderrFile contents, nil)
 		result
 	)
 	


### PR DESCRIPTION
This PR fixes an issue with `System runCommand` related to reading the contents of a non-existent file.
Read a thread here: https://github.com/IoLanguage/eerie/issues/30