### PR TITLE
Update addons search paths

### DIFF
--- a/InstallEerie.cmake
+++ b/InstallEerie.cmake
@@ -1,6 +1,10 @@
+IF(UNIX AND NOT APPLE)
+    execute_process(COMMAND ldconfig)
+ENDIF(UNIX AND NOT APPLE)
+
 message("------------Installing Eerie------------")
 IF(WIN32)
     execute_process(COMMAND ${CMAKE_INSTALL_PREFIX}/io ${CMAKE_SOURCE_DIR}/setup.io)
 ELSE()
     execute_process(COMMAND ${CMAKE_INSTALL_PREFIX}/bin/io ${CMAKE_SOURCE_DIR}/setup.io)
-ENDIF()
+ENDIF(WIN32)

--- a/libs/iovm/io/AddonLoader.io
+++ b/libs/iovm/io/AddonLoader.io
@@ -98,12 +98,21 @@ Addon := Object clone do(
 
 AddonLoader := Object clone do(
     //doc Addon searchPaths Returns the list of paths to search for addons.
-    searchPaths := list("eerie/base/addons", 
-        "eerie/activeEnv/addons", 
-        (System installPrefix .. "/eerie/base/addons") asOSPath,
-        (System installPrefix .. "/eerie/activeEnv/addons") asOSPath,
-        (System installPrefix .. "/lib/io/eerie/base/addons") asOSPath,
-        (System installPrefix .. "/lib/io/eerie/activeEnv/addons") asOSPath
+
+    searchPaths := method(
+        platform := System platform asLowercase
+        eerieBasePath := nil
+        eerieActiveEnvPath := nil
+
+        if(platform == "windows" or platform == "mingw",
+            eerieBasePath := (System installPrefix .. "/eerie/base/addons") asOSPath
+            eerieActiveEnvPath := (System installPrefix .. "/eerie/activeEnv/addons") asOSPath
+            ,
+            eerieBasePath := ("~/.eerie/base/addons" stringByExpandingTilde) asOSPath
+            eerieActiveEnvPath := ("~/.eerie/activeEnv/addons" stringByExpandingTilde) asOSPath
+        )
+
+        return list("eerie/base/addons", "eerie/activeEnv/addons", eerieBasePath, eerieActiveEnvPath)
     )
 
     //doc Addon appendSearchPath(aSequence) Appends the argument to the list of search paths.

--- a/libs/iovm/io/Y_Path.io
+++ b/libs/iovm/io/Y_Path.io
@@ -1,5 +1,5 @@
 tildeExpandsTo := method(
-    platform := System platform
+    platform := System platform asLowercase
 
     if(platform == "windows" or platform == "mingw",
         # Windows

--- a/libs/iovm/source/IoNumber.h
+++ b/libs/iovm/source/IoNumber.h
@@ -7,7 +7,7 @@
 
 #include <math.h>
 #define _GNU_SOURCE // for NAN macro, round
-#include <endian.h>
+#include <sys/types.h>
 
 #include "IoVMApi.h"
 


### PR DESCRIPTION
- fix build on macos (<endian.h> not found);
- update addons search paths as of eerie has been moved;
- fix `stringByExpandingTIlde` on windows.