### PR TITLE
feat(initial docker image): prep starter io image for community

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:latest
+
+# Install build dependencies
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt install -y tzdata && \
+    apt-get install -y \
+    build-essential \
+    git \
+    cmake
+
+# clone latest from Io repository into src/io
+WORKDIR /src
+RUN git clone --recursive https://github.com/IoLanguage/io.git
+
+# build and install Io
+WORKDIR /src/io
+RUN mkdir build 
+WORKDIR /src/io/build
+RUN cmake ..
+RUN make
+RUN make install
+
+ENTRYPOINT [ "bash" ]

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,0 +1,11 @@
+## Docker for Io Language
+
+Developed while pursuing 7 Languages in 7 Weeks. This image should provide a reusable 'environment' for development with Io.
+
+Naturally this depends on docker, so you'll need it installed before this will be useful. Afterwards, you should be able to run the two shell scripts to built and then run the container.
+
+## Looking towards the future
+
+In Theory this image could be used as the basis for future, more useful Io containers, that you could import your own projects into.
+
+In practice it might be good to add this Image to Docker Hub, if it proves sufficiently useful, with tags to enable users to leverage specific tags. That would allow us to ease the initiation of new developers into the language.

--- a/tools/docker/buildDockerIo.sh
+++ b/tools/docker/buildDockerIo.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Assumes you've already installed docker on your system
+# Build script for Docker Io image
+docker build -t io .

--- a/tools/docker/runDockerIo.sh
+++ b/tools/docker/runDockerIo.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Assumes you've already run 'buildDockerIo'
+# Run interactive Io image, with automatic teardown
+docker run  -it --rm io


### PR DESCRIPTION
Related to #433 

I have compiled a Docker Image to aid new comers to the community. When built it will download the latest edition of Io to a virtual machine equipped to support and build the interpreters. From there, either you could extend the Dockerfile to import your own Io program, or we might load it as a base image to DockerHub and build new containers from there.
