### PR TITLE
don't include sys/sysctl.h on linux

### DIFF
--- a/libs/iovm/source/IoSystem.c
+++ b/libs/iovm/source/IoSystem.c
@@ -22,7 +22,7 @@ Contains methods related to the IoVM.
 #if defined(__NetBSD__) || defined(__OpenBSD__)
 # include <sys/param.h>
 #endif
-#ifndef __CYGWIN__
+#ifndef __CYGWIN__ || defined(linux)
 # include <sys/sysctl.h>
 #endif
 #endif


### PR DESCRIPTION
The header was removed in glibc and is not present in musl