### PR TITLE
don't include sys/sysctl.h on linux

### DIFF
--- a/libs/iovm/source/IoSystem.c
+++ b/libs/iovm/source/IoSystem.c
@@ -22,7 +22,7 @@ Contains methods related to the IoVM.
 #if defined(__NetBSD__) || defined(__OpenBSD__)
 # include <sys/param.h>
 #endif
-#ifndef __CYGWIN__
+#if defined(HAVE_SYS_SYSCTL_H) && !defined(__GLIBC__)
 # include <sys/sysctl.h>
 #endif
 #endif


### PR DESCRIPTION
This is a continuation of https://github.com/IoLanguage/io/pull/445
glibc 2.32 removed <sys/sysctl.h>
The Fix was suggested by https://github.com/IoLanguage/io/pull/445#discussion_r581458969