### PR TITLE
Fix for issue #455

### DIFF
--- a/extras/win32vc2005/freeglut-2.2.0/src/freeglut_structure.c
+++ b/extras/win32vc2005/freeglut-2.2.0/src/freeglut_structure.c
@@ -621,9 +621,9 @@ void fgListRemove(SFG_List *list, SFG_Node *node)
 {
     SFG_Node *ln;
 
-    if( ln = (SFG_Node *)node->Next )
+    if( (ln = (SFG_Node *)node->Next) )
         ln->Prev = node->Prev;
-    if( ln = (SFG_Node *)node->Prev )
+    if( (ln = (SFG_Node *)node->Prev) )
         ln->Next = node->Next;
     if( (ln = (SFG_Node *)list->First) == node )
         list->First = node->Next;

--- a/libs/basekit/source/UArray.c
+++ b/libs/basekit/source/UArray.c
@@ -12,6 +12,7 @@ license: See _BSDLicense.txt.
 #include <string.h>
 #include <ctype.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <limits.h>
 
 size_t CTYPE_size(CTYPE type) {
@@ -919,9 +920,9 @@ void UArray_at_putAll_(UArray *self, size_t pos, const UArray *other) {
             TYPE1 v1 = ((TYPE1 *)self->data)[i];                               \
             TYPE2 v2 = ((TYPE2 *)other->data)[i];                              \
             if (v1 != v2)                                                      \
-                return 0;                                                      \
+                return false;                                                  \
         }                                                                      \
-        return 1;                                                              \
+        return true;                                                           \
     }
 
 #define UARRAY_GT_TYPES(OP2, TYPE1, self, TYPE2, other)                        \
@@ -932,9 +933,9 @@ void UArray_at_putAll_(UArray *self, size_t pos, const UArray *other) {
             TYPE1 v1 = ((TYPE1 *)self->data)[i];                               \
             TYPE2 v2 = ((TYPE2 *)other->data)[i];                              \
             if (v1 < v2)                                                       \
-                return 0;                                                      \
+                return false;                                                  \
         }                                                                      \
-        return 1;                                                              \
+        return true;                                                           \
     }
 
 #define UARRAY_LT_TYPES(OP2, TYPE1, self, TYPE2, other)                        \
@@ -945,9 +946,9 @@ void UArray_at_putAll_(UArray *self, size_t pos, const UArray *other) {
             TYPE1 v1 = ((TYPE1 *)self->data)[i];                               \
             TYPE2 v2 = ((TYPE2 *)other->data)[i];                              \
             if (v1 > v2)                                                       \
-                return 0;                                                      \
+                return false;                                                  \
         }                                                                      \
-        return 1;                                                              \
+        return true;                                                           \
     }
 
 int UArray_compare_(const UArray *self, const UArray *other) {
@@ -971,14 +972,14 @@ int UArray_compare_(const UArray *self, const UArray *other) {
     return 0;
 }
 
-int UArray_equals_(const UArray *self, const UArray *other) {
+bool UArray_equals_(const UArray *self, const UArray *other) {
     if (self->size != other->size)
-        return 0;
+        return false;
     DUARRAY_OP(UARRAY_EQ_TYPES, NULL, self, other);
-    return 0;
+    return false;
 }
 
-int UArray_greaterThan_(const UArray *self, const UArray *other) {
+bool UArray_greaterThan_(const UArray *self, const UArray *other) {
     if (self->encoding == CENCODING_NUMBER) {
         DUARRAY_OP(UARRAY_GT_TYPES, NULL, self, other);
     }
@@ -986,7 +987,7 @@ int UArray_greaterThan_(const UArray *self, const UArray *other) {
     return UArray_compare_(self, other) > 0;
 }
 
-int UArray_lessThan_(const UArray *self, const UArray *other) {
+bool UArray_lessThan_(const UArray *self, const UArray *other) {
     if (self->encoding == CENCODING_NUMBER) {
         DUARRAY_OP(UARRAY_LT_TYPES, NULL, self, other);
     }
@@ -994,33 +995,33 @@ int UArray_lessThan_(const UArray *self, const UArray *other) {
     return UArray_compare_(self, other) < 0;
 }
 
-int UArray_greaterThanOrEqualTo_(const UArray *self, const UArray *other) {
+bool UArray_greaterThanOrEqualTo_(const UArray *self, const UArray *other) {
     if (self->encoding == CENCODING_NUMBER) {
-        if (UArray_greaterThan_(self, other) | UArray_equals_(self, other)) {
-            return 1;
+        if (UArray_greaterThan_(self, other) || UArray_equals_(self, other)) {
+            return true;
         } else {
-            return 0;
+            return false;
         }
     }
 
     return UArray_compare_(self, other) >= 0;
 }
 
-int UArray_lessThanOrEqualTo_(const UArray *self, const UArray *other) {
+bool UArray_lessThanOrEqualTo_(const UArray *self, const UArray *other) {
     if (self->encoding == CENCODING_NUMBER) {
-        if (UArray_lessThan_(self, other) | UArray_equals_(self, other)) {
-            return 1;
+        if (UArray_lessThan_(self, other) || UArray_equals_(self, other)) {
+            return true;
         } else {
-            return 0;
+            return false;
         }
     }
 
     return UArray_compare_(self, other) <= 0;
 }
 
-int UArray_isZero(const UArray *self) {
-    UARRAY_FOREACH(self, i, v, if (v) return 0;)
-    return 1;
+bool UArray_isZero(const UArray *self) {
+    UARRAY_FOREACH(self, i, v, if (v) return false;)
+    return true;
 }
 
 // find

--- a/libs/basekit/source/UArray.h
+++ b/libs/basekit/source/UArray.h
@@ -9,6 +9,7 @@
 
 #include "Common.h"
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stddef.h>
 
@@ -165,14 +166,14 @@ BASEKIT_API UArray *UArray_slice(const UArray *self, long start, long end);
 // compare
 
 BASEKIT_API int UArray_compare_(const UArray *self, const UArray *other);
-BASEKIT_API int UArray_equals_(const UArray *self, const UArray *other);
-BASEKIT_API int UArray_greaterThan_(const UArray *self, const UArray *other);
-BASEKIT_API int UArray_lessThan_(const UArray *self, const UArray *other);
-BASEKIT_API int UArray_greaterThanOrEqualTo_(const UArray *self,
+BASEKIT_API bool UArray_equals_(const UArray *self, const UArray *other);
+BASEKIT_API bool UArray_greaterThan_(const UArray *self, const UArray *other);
+BASEKIT_API bool UArray_lessThan_(const UArray *self, const UArray *other);
+BASEKIT_API bool UArray_greaterThanOrEqualTo_(const UArray *self,
                                              const UArray *other);
-BASEKIT_API int UArray_lessThanOrEqualTo_(const UArray *self,
+BASEKIT_API bool UArray_lessThanOrEqualTo_(const UArray *self,
                                           const UArray *other);
-BASEKIT_API int UArray_isZero(const UArray *self);
+BASEKIT_API bool UArray_isZero(const UArray *self);
 
 // contains
 


### PR DESCRIPTION
Rewrote UArray comparison functions to use boolean type instead of int type to
resolve any ambiguity. Modified signatures of the corresponding functions.

Ran tests and checked that they pass:

```
$ LD_LIBRARY_PATH=`pwd`/install/lib/ ../install/bin/io
../libs/iovm/tests/correctness/run.io
......................................................................
......................................................................
......................................................................
....................
----------------------------------------------------------------------
Ran 230 tests in 3.0030000000000001s

OK                                                                 run
```