### PR TITLE
Check for NULLs when getting the 'next' message

### DIFF
--- a/libs/iovm/source/IoMessage_opShuffle.c
+++ b/libs/iovm/source/IoMessage_opShuffle.c
@@ -383,9 +383,15 @@ void Levels_attach(Levels *self, IoMessage *msg, List *expressions) {
 
             IoMessage *value = IoMessage_deepCopyOf_(DATA(msg)->next);
             IoMessage_rawSetNext_(value, NULL);
-
-            IoMessage *rest =
-                IoMessage_deepCopyOf_(DATA(DATA(msg)->next)->next);
+            // Step forward twice to the "next" part of the expression,
+            // which may be NULL, and make a copy.
+            IoMessage *rest = DATA(msg->next);
+            if (rest) {
+                rest = DATA(rest->next);
+            }
+            if (rest) {
+                rest = IoMessage_deepCopyOf_(rest);
+            }
             IoMessage_rawSetNext_(slotNameMessage, rest);
             IoMessage_addArg_(slotNameMessage, value);
 


### PR DESCRIPTION
## Description
Check for NULLs which otherwise would cause the REPL to crash with a segmentation fault

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues
<!-- Link any related issues here using #issue_number -->
Fixes #477

## Changes Made
Add null checks before dereferencing

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass
- [ ] Added new tests for the changes
- [ ] Tested on the following platforms:
  - [ ] Linux
  - [ ] macOS (Intel)
  - [X] macOS (Apple Silicon)
  - [X] Windows
  - [ ] Other: 

## Test Commands
```
Io> a := list(1, 2, 3, 4)
==> list(1, 2, 3, 4)
Io> a at(0)
==> 1
Io> a at(0) = 1
```
(crashes without this PR)

## Checklist
<!-- Mark completed items with an "x" -->
- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
<!-- Takes longer to fill this form than to write the code. -->