### PR TITLE
Make toBase on Windows behave more like other platforms

### DIFF
--- a/libs/iovm/source/IoSeq_immutable.c
+++ b/libs/iovm/source/IoSeq_immutable.c
@@ -854,22 +854,21 @@ IO_METHOD(IoSeq, toBase) {
     /*doc Sequence toBase(aNumber)
     Returns a Sequence containing the receiver (which is
     assumed to be a base 10 number) converted to the specified base.
-    Only base 8 and 16 are currently supported.
     */
 
     const char *const table = "0123456789abcdefghijklmnopqrstuvwxyz";
     int base = IoMessage_locals_intArgAt_(m, locals, 0);
     char buf[64], *ptr = buf + 64;
-    unsigned long n = 0;
+    uintptr_t n = 0;
 
     if (base < 2 || base > 36) {
         IoState_error_(IOSTATE, m, "conversion to base %i not supported", base);
     }
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
-    n = strtoul(IoSeq_asCString(self), NULL, 0);
+    n = (uintptr_t)strtoull(IoSeq_asCString(self), NULL, 0);
 #else
-    n = (unsigned long)IoSeq_asDouble(self);
+    n = (uintptr_t)IoSeq_asDouble(self);
 #endif
 
     /* Build the converted string backwards. */


### PR DESCRIPTION
## Description

The message `toBase` treats its receiver, a sequence, as a number formatted as a string, and returns a number formatted as a string in a different base.

On windows MSVC it is not able to deal with a number greater than 0xFFFFFFFF because `unsigned long` on that platform is 32-bit. This causes a problem for `uniqueHexId` because the unique id is a pointer-sized (i.e. 64-bit) quantity. Other messages which rely on `uniqueHexId`, such as `asSimpleString` are affected.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues
<!-- Link any related issues here using #issue_number -->
Fixes #480

## Changes Made
The current code parses a string to a number, then converts that number to a string.
* Use `strtoull` instead of `strtoul` on Windows only.
* Use an explicitly sized type, namely `uint64_t`, for intermediate values

Also, remove a code comment says "Only base 8 and 16 are currently supported" because this is untrue.

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass
- [ ] Added new tests for the changes
- [ ] Tested on the following platforms:
  - [ ] Linux
  - [ ] macOS (Intel)
  - [ ] macOS (Apple Silicon)
  - [X] Windows
  - [ ] Other: 

## Test Commands

### Before:
```bash
Io> Object asSimpleString
==> Object_0xffffffff
```
### After:
```bash
Io> Object asSimpleString
==> Object_0x146297d81c0
```

## Checklist
<!-- Mark completed items with an "x" -->
- [ ] My code follows the project's style guidelines
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
